### PR TITLE
Use crypto DB in evolution loop

### DIFF
--- a/agent_eval.py
+++ b/agent_eval.py
@@ -41,3 +41,33 @@ def evaluate_agent(agent, prices, initial_cash=1000):
         portfolio_history.append(cash + crypto * price)
 
     return portfolio_history[-1], portfolio_history
+
+
+def evaluate_agent_multi(agent, price_df, initial_cash=1000):
+    """Evaluate an agent across multiple coins.
+
+    Parameters
+    ----------
+    agent : Agent
+        The trading agent.
+    price_df : pandas.DataFrame
+        DataFrame where each column is the price series of a crypto asset.
+    initial_cash : float, optional
+        Starting portfolio value.
+
+    Returns
+    -------
+    float
+        Final portfolio value when trading each asset independently and
+        rebalancing the cash between them sequentially.
+    list
+        List of portfolio histories per asset.
+    """
+    results = []
+    for column in price_df.columns:
+        final_val, history = evaluate_agent(agent, price_df[column].values,
+                                            initial_cash=initial_cash)
+        results.append((final_val, history))
+
+    final_values = [r[0] for r in results]
+    return sum(final_values) / len(final_values), [r[1] for r in results]


### PR DESCRIPTION
## Summary
- add helper to load real crypto data from Postgres
- sample 150 synced 300 step windows for evolution
- evaluate agents on all five coins and keep top five
- mutate best agents with 1% mutation rate and use t‑tests to replace parents
- default to 10k generations

## Testing
- `python -m py_compile Agent.py data_generation.py agent_eval.py mutations.py evo_loop.py`
- `python - <<'PY'
from data_generation import load_real_crypto_data
try:
    df = load_real_crypto_data()
    print('Loaded DF shape', df.shape)
except Exception as e:
    print('LOAD ERROR', e)
PY
`
- `python evo_loop.py 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68557242a034832bb0e73c0ddb9878d7